### PR TITLE
ceph-ansible: add add_rgws scenario to CI

### DIFF
--- a/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
+++ b/ceph-ansible-pipeline/config/definitions/ceph-ansible-pipeline.yml
@@ -534,7 +534,7 @@
             #!/bin/bash
             set -x
             # if the target branch is not stable-3.2 then we DON'T RUN these tests
-            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|master ]]; then
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-defaults/tasks/facts.yml|roles/ceph-osd|ceph-validate'
@@ -555,7 +555,7 @@
             #!/bin/bash
             set -x
             # if the target branch is stable-3.2 then we RUN these tests.
-            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|master ]]; then
+            if [[ "$ghprbTargetBranch" =~ stable-3.[0-1]|stable-4.0|master ]]; then
               exit 1
             fi
             git diff --name-only $(git show HEAD | grep Merge | head -n 1 | cut -d ':' -f2) | grep -E 'roles/ceph-rgw/tasks/multisite|tests/functional/centos/7/rgw-multisite'


### PR DESCRIPTION
Add add_rgws scenario to CI so that it can be tested against master.

Signed-off-by: Rishabh Dave <ridave@redhat.com>